### PR TITLE
feat: add working days input and update calculations

### DIFF
--- a/content.js
+++ b/content.js
@@ -114,30 +114,38 @@ function calculateWorkDays(deliveryElement, workDaysInfoElement) {
     const itemPrice = extractPrice(deliveryElement);
     console.log('Pay2Days: Extracted price:', itemPrice);
     
-    chrome.storage.local.get(['salary', 'submittedData'], function(result) {
+    chrome.storage.local.get(['salary', 'workingDays', 'submittedData'], function(result) {
         console.log('Pay2Days: Storage data:', result);
         
         let monthlySalary = null;
+        let workingDaysPerMonth = 22; // default value
         
         // Prioritize submitted data
         if (result.submittedData && result.submittedData.salary) {
             monthlySalary = result.submittedData.salary;
-            console.log('Pay2Days: Using submitted salary:', monthlySalary);
-        } else if (result.salary) {
-            monthlySalary = parseFloat(result.salary);
-            console.log('Pay2Days: Using input salary:', monthlySalary);
+            workingDaysPerMonth = result.submittedData.workingDays || 22;
+            console.log('Pay2Days: Using submitted data - salary:', monthlySalary, 'working days:', workingDaysPerMonth);
         } else {
-            console.log('Pay2Days: No salary data found');
+            if (result.salary) {
+                monthlySalary = parseFloat(result.salary);
+                console.log('Pay2Days: Using input salary:', monthlySalary);
+            }
+            if (result.workingDays) {
+                workingDaysPerMonth = parseInt(result.workingDays);
+                console.log('Pay2Days: Using input working days:', workingDaysPerMonth);
+            } else {
+                console.log('Pay2Days: Using default working days:', workingDaysPerMonth);
+            }
         }
         
-        if (itemPrice && monthlySalary && monthlySalary > 0) {
-            const workingDays = (itemPrice / monthlySalary) * 22;
+        if (itemPrice && monthlySalary && monthlySalary > 0 && workingDaysPerMonth > 0) {
+            const workingDays = (itemPrice / monthlySalary) * workingDaysPerMonth;
             const roundedDays = Math.ceil(workingDays);
             
-            console.log(`Pay2Days: Calculation - Price: ${itemPrice}, Salary: ${monthlySalary}, Working Days: ${workingDays}, Rounded: ${roundedDays}`);
+            console.log(`Pay2Days: Calculation - Price: ${itemPrice}, Salary: ${monthlySalary}, Working Days per Month: ${workingDaysPerMonth}, Working Days: ${workingDays}, Rounded: ${roundedDays}`);
             
             workDaysInfoElement.textContent = `${roundedDays} hari kerja`;
-            workDaysInfoElement.title = `Harga: Rp ${itemPrice.toLocaleString('id-ID')}\nGaji bulanan: Rp ${monthlySalary.toLocaleString('id-ID')}\nAnda perlu ${roundedDays} hari kerja untuk membeli barang ini`;
+            workDaysInfoElement.title = `Harga: Rp ${itemPrice.toLocaleString('id-ID')}\nGaji bulanan: Rp ${monthlySalary.toLocaleString('id-ID')}\nHari kerja per bulan: ${workingDaysPerMonth}\nAnda perlu ${roundedDays} hari kerja untuk membeli barang ini`;
             
             // Change color based on number of work days
             if (roundedDays <= 7) {

--- a/popup.html
+++ b/popup.html
@@ -28,6 +28,10 @@
                     <label for="salaryInput">Monthly Salary:</label>
                     <input type="number" id="salaryInput" placeholder="Enter monthly salary">
                 </div>
+                <div class="input-group">
+                    <label for="workingDaysInput">Working Days per Month:</label>
+                    <input type="number" id="workingDaysInput" placeholder="Enter working days (default: 22)" value="22" min="1" max="31">
+                </div>
                 <button id="submitBtn" class="btn btn-submit">Submit</button>
             </div>
             


### PR DESCRIPTION
This pull request adds support for customizing the number of working days per month in the Pay2Days extension, allowing users to specify this value for more accurate calculations. The changes update both the popup interface and the calculation logic to use the user-provided working days value instead of a fixed default.

**User input enhancements:**

* Added a new input field for "Working Days per Month" in `popup.html`, allowing users to specify the number of working days (default: 22).
* Updated `popup.js` to handle the new input: validates its presence, saves/loads its value, and ensures the submit button is only enabled when all fields are filled. [[1]](diffhunk://#diff-3df6958c77d615b266b54fcf12fadf313e7c1e4b168f0c61ea8c3424eb39eb8cR9) [[2]](diffhunk://#diff-3df6958c77d615b266b54fcf12fadf313e7c1e4b168f0c61ea8c3424eb39eb8cL21-R22) [[3]](diffhunk://#diff-3df6958c77d615b266b54fcf12fadf313e7c1e4b168f0c61ea8c3424eb39eb8cL168-R220)

**Calculation logic improvements:**

* Modified `content.js` to use the user-specified working days per month (from submitted data or input) in the work days calculation, with a fallback to the default value if not provided. The tooltip now displays the working days value used.

**Real-time updates:**

* Implemented real-time recalculation and update of work days when the working days input value changes, similar to the behavior for salary changes.